### PR TITLE
Add multiple device support; fixed and usability improvements

### DIFF
--- a/SerialFlash.c
+++ b/SerialFlash.c
@@ -31,7 +31,6 @@ size_t AT45ChipSize=0;
 size_t AT45PageSize=0;
 bool AT45doRDSR(unsigned char* cSR, int Index)
 {
-    unsigned char Out=0xD7;
     CNTRPIPE_RQ rq ;
     unsigned char vInstruction;    //size 1
 

--- a/board.c
+++ b/board.c
@@ -273,7 +273,7 @@ bool BlinkProgBoard(bool boIsV5,int Index)
     return true;
 }
 
-bool ReadOnBoardFlash(unsigned char* Data,bool ReadUID,int Index)
+static void ReadOnBoardFlash(unsigned char* Data,bool ReadUID,int Index)
 {
     CNTRPIPE_RQ rq ;
     unsigned char vBuffer[16] ;
@@ -294,9 +294,8 @@ bool ReadOnBoardFlash(unsigned char* Data,bool ReadUID,int Index)
     rq.Length = 16 ;
 
     if(InCtrlRequest(&rq, vBuffer,16,Index)==SerialFlash_FALSE)
-    {
-        return false;
-    }
+        return;
+
     memcpy(Data,vBuffer,16);
 }
 

--- a/board.h
+++ b/board.h
@@ -16,7 +16,6 @@ bool SetLEDOnOff(size_t Color,int Index);
 bool SetCS(size_t value,int Index);
 bool SetIOModeToSF600(size_t value,int Index);
 bool BlinkProgBoard(bool boIsV5,int Index);
-bool ReadOnBoardFlash(unsigned char* Data,bool ReadUID,int Index);
 bool LeaveSF600Standalone(bool Enable,int USBIndex);
 bool SetSPIClockValue(unsigned short v,int Index);
 unsigned int ReadUID(int Index);

--- a/dpcmd.c
+++ b/dpcmd.c
@@ -19,6 +19,9 @@
 #include "dpcmd.h"
 #include "board.h"
 #include "FlashCommand.h"
+#include "ChipInfoDb.h"
+#include "parse.h"
+
 #define min(a,b) (a>b? b:a)
 
 extern unsigned char* pBufferForLastReadData;
@@ -1296,7 +1299,7 @@ bool CalChecksum(void)
 
         if( g_uiAddr==0 && g_uiLen ==0)
         {
-            printf("\nChecksum of the whole chip(address starting from: 0x%zX, 0x%X bytes in total): %08X\n",g_uiAddr,Chip_Info.ChipSizeInByte,CRC32(pBufferForLastReadData,Chip_Info.ChipSizeInByte));
+            printf("\nChecksum of the whole chip(address starting from: 0x%X, 0x%zX bytes in total): %08X\n",g_uiAddr,Chip_Info.ChipSizeInByte,CRC32(pBufferForLastReadData,Chip_Info.ChipSizeInByte));
         }
         else
         {

--- a/dpcmd.c
+++ b/dpcmd.c
@@ -435,7 +435,7 @@ void WriteLog(int ErrorCode, bool Init)
 
 int GetConfigVer()
 {
-	char path[512],fname[256];
+	char path[512];
 	char file_line_buf[512];
 	char test[80];
 	char *pch,*tok;
@@ -444,10 +444,7 @@ int GetConfigVer()
 	FILE* fp;       /*Declare file pointer variable*/
 	getExecPath(path);
 	if ((fp = fopen(path,"rt")) == NULL)
-	{
-		fprintf(stderr,"Error opening file: %s\n",fname);
 		return 1;
-	}
 
 	while(fgets(file_line_buf, 512, fp) != NULL)
 	{

--- a/dpcmd.c
+++ b/dpcmd.c
@@ -1334,8 +1334,11 @@ bool Wait(const char* strOK,const char* strFail)
        if(g_bDisplayTimer==true)
        {
             timersub(&tv, &basetv, &diff);
-            printf("%0.6f\t s elapsed\r",diff.tv_sec + 0.000001 * diff.tv_usec);
+            printf("%0.0fs elapsed\r",diff.tv_sec + 0.000001 * diff.tv_usec);
+            fflush(stdout);
       }
+
+      sleep(1);
     }
     printf("\n%s\n",g_is_operation_successful? strOK : strFail);
     g_bStatus=g_is_operation_successful;

--- a/dpcmd.c
+++ b/dpcmd.c
@@ -147,7 +147,7 @@ struct option long_options[] = {
      { "lock-start",            1,   NULL,    'S'     },
      { "lock-length",           1,   NULL,    'N'     },
      { "blink",                 1,   NULL,    'B'     },
-//     { "device",                1,   NULL,    'D'     },
+     { "device",                1,   NULL,    'D'     },
 //     { "fix-device",            1,   NULL,    'F'     },
      { "list-device-id",        1,   NULL,    'V'     },
      { "timeout",               1,   NULL,    't'     },
@@ -476,7 +476,7 @@ int main(int argc, char *argv[])
 	int iExitCode=EXCODE_PASS;
 	bool bDetect=false;
 
-	printf("\nDpCmd Linux 1.1.2.%02d Engine Version:\nLast Built on Mar 13 2017\n\n",GetConfigVer());
+	printf("\nDpCmd Linux 1.1.3.%02d Engine Version:\nLast Built on Jul 17 2017\n\n",GetConfigVer());
 
 	g_ucOperation=0;
 	GetLogPath(g_LogPath);
@@ -486,12 +486,6 @@ int main(int argc, char *argv[])
 		cli_classic_usage(false);
 		return 0;
 	}
-	if(OpenUSB()==0)
-		iExitCode=EXCODE_FAIL_USB;
-
-//	QueryBoard(0);
-	LeaveStandaloneMode(0);
-	QueryBoard(0);
 
 	while((c = getopt_long (argc, argv, short_options, long_options, NULL)) != -1)
 	{
@@ -578,8 +572,7 @@ int main(int argc, char *argv[])
 				g_ucOperation |= BLINK;
 				break;
 			case 'D': // device
-				l_opt_arg = optarg;
-				printf("activate only the programmer connected to USBx (with arg: %s)\n", l_opt_arg);
+				devpath = optarg;
 				break;
 			case 'F':
 				l_opt_arg = optarg;
@@ -633,6 +626,14 @@ int main(int argc, char *argv[])
 				break;
 		}
     }
+
+	if(OpenUSB()==0)
+		iExitCode=EXCODE_FAIL_USB;
+
+//	QueryBoard(0);
+	LeaveStandaloneMode(0);
+	QueryBoard(0);
+
 	if(bDetect==true)
 	{
 //		printf("%s\r\n",g_LogPath);
@@ -812,11 +813,7 @@ void cli_classic_usage(bool IsShowExample)
 //	       "                                            note: the sequence is assigned by OS during USB plug-in\n"
 	       "                                            - 1: Blink the programmer connected to USB1 3 times.\n"
 //	       "                                            - n: Blink the programmer connected to USBn 3 times.\n"
-//	       "    --device arg                            (work with all Basic Switchs)\n"
-//	       "                                            - 1: activate only the programmer connected to USB1\n"
-//	       "                                            - n: activate only the programmer connected to USBn\n"
-//	       "                                            note: if '--device' is not used, the command will\n"
-//	       "                                            be executed on all connected programmer.\n"
+	       "    --device <device-path>                  use programmer at <device-path> eg /dev/bus/usb/007/009 rather than first detected\n"
 //	       "    --fix-device arg                        Fix programmer serial number with programmer sequence.\n"
 //	       "                                            - instructions must be enclosed in double quotation marks(\"\")\n"
 //	       "                                            Example:\n"

--- a/parse.c
+++ b/parse.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <libgen.h>
+#include <ctype.h>
 
 #include "Macro.h"
 #include "ChipInfoDb.h"
@@ -619,7 +621,7 @@ void Dedi_List_AllChip()
 	/*error message & return (1) control to the OS*/
 	if ((fp = fopen(Path,"rt")) == NULL){
 		fprintf(stderr,"Error opening file: %s\n",fname);
-		return 1;
+		return;
 	}
 	sz=fsize(fp);
 	file_buf=(char*)malloc(sz);

--- a/parse.c
+++ b/parse.c
@@ -39,7 +39,7 @@ int Dedi_Search_Chip_Db(long RDIDCommand, long UniqueID, CHIP_INFO *Chip_Info, i
 {
 	FILE* fp;       /*Declare file pointer variable*/
 	int    found_flag = 0;
-	char file_line_buf[linebufsize], *tok, fname[256], *file_buf, test[256];
+	char file_line_buf[linebufsize], *tok, *file_buf, test[256];
 	char* pch;
 	long sz=0;
 	char Path[512];
@@ -49,7 +49,7 @@ int Dedi_Search_Chip_Db(long RDIDCommand, long UniqueID, CHIP_INFO *Chip_Info, i
      /*error message & return (1) control to the OS*/
 	if ((fp = fopen(Path,"rt")) == NULL)
 	{
-		fprintf(stderr,"Error opening file: %s\n",fname);
+		fprintf(stderr,"Error opening file: %s\n", Path);
 		return 1;
 	}
 	sz=fsize(fp);

--- a/parse.h
+++ b/parse.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void Dedi_List_AllChip();
+int Dedi_Search_Chip_Db(long RDIDCommand, long UniqueID, CHIP_INFO *Chip_Info, int search_all);

--- a/usbdriver.c
+++ b/usbdriver.c
@@ -90,11 +90,17 @@ static int ResolveUSBDevice(void)
         return 0;
 
     if (stat(devpath, &stats))
-        return 0;
+    {
+        fprintf(stderr, "Failed to open %s\n", devpath);
+        exit(1);
+    }
 
     // skip non-USB devices
     if (major(stats.st_rdev) != 189)
-        return 0;
+    {
+        fprintf(stderr, "Device %s is not a Dediprog\n", devpath);
+        exit(1);
+    }
 
     // find USB bus and device numbers
     snprintf(busno, sizeof(busno), "%03u", (minor(stats.st_rdev) >> 7) + 1);
@@ -115,7 +121,8 @@ static int ResolveUSBDevice(void)
         }
     }
 
-    return 0;
+    fprintf(stderr, "Device %s is not a Dediprog\n", devpath);
+    exit(1);
 }
 
 

--- a/usbdriver.h
+++ b/usbdriver.h
@@ -26,7 +26,6 @@
 
 #define DEFAULT_TIMEOUT                             30000
 
-static usb_dev_handle *dediprog_handle=NULL;
 #define MAX_Dev_Index   10
 
 typedef struct usb_device_entry {
@@ -71,6 +70,7 @@ int dediprog_set_vpp_voltage(int volt);
 
 long flash_ReadId(unsigned int read_id_code, unsigned int out_data_size ,int Index);
 
+bool Is_usbworking(void);
 
 int BulkPipeWrite(unsigned char *pBuff, unsigned int size,unsigned int timeOut, int Index);
 

--- a/usbdriver.h
+++ b/usbdriver.h
@@ -44,7 +44,7 @@ typedef struct {
 
 
 usb_device_entry_t   usb_device_entry[MAX_Dev_Index];
-
+extern const char *devpath;
 
 /* Set/clear LEDs on dediprog */
 #define PASS_ON		(0 << 0)


### PR DESCRIPTION
Allows Dediprog device to be specified eg via dpcmd --device /dev/dediprog-dut1, which allows udev rules to be setup to facilitate multiple devices.

Various memory violations and build warnings have been fixed, and usability improved by writing to the console at a reasonable rate to display progress.