### PR TITLE
Fix "Error: Programmers are not connected" by adding prototype for Is_usbworking

### DIFF
--- a/usbdriver.h
+++ b/usbdriver.h
@@ -28,6 +28,8 @@
  
 #define MAX_Dev_Index   16
 
+bool Is_usbworking(int Index);
+
 typedef struct usb_device_entry {
     struct usb_device usb_device_handler;
     int valid;


### PR DESCRIPTION
Without this, dpcmd produces "Error: Programmers are not connected."
when trying to do anything other than detection. The call in dpcmd.c
treats the function as returning an int rather than a bool, which causes
checks like Is_usbworking(0)==true to fail. With this change, that check
succeeds, allowing dpcmd to proceed.