### PR TITLE
make file ending detection slightly more stable

### DIFF
--- a/project.c
+++ b/project.c
@@ -195,7 +195,15 @@ int GetFileFormatFromExt(const char* csPath)
 
     while(csPath[i] != '.')
     {
+        if (i==0) {
+            return BIN;
+        }
+
         i--;
+    }
+
+    if (length-i > 5) {
+        return BIN;
     }
 
     for(j=i;j<length; j++)


### PR DESCRIPTION
currently the tool crashes if the file ending has 5 or more
letters (like .jffs2)