### PR TITLE
Fix of global variable usage (allowing GCC 10 compilation without linker errors)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 PROGRAM = dpcmd
 CC      = gcc
-CFLAGS  = -O2 -Wall -lpthread -std=gnu99
+CFLAGS  = -O2 -Wall -lpthread -std=gnu99 -fcommon
 PREFIX ?= /usr/local
 
 UNAME_OS := $(shell which lsb_release 2>/dev/null && lsb_release -si)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 PROGRAM = dpcmd
 CC      = gcc
-CFLAGS  = -O2 -Wall -lpthread -std=gnu99 -fcommon
+CFLAGS  = -O2 -Wall -lpthread -std=gnu99
 PREFIX ?= /usr/local
 
 UNAME_OS := $(shell which lsb_release 2>/dev/null && lsb_release -si)

--- a/dpcmd.h
+++ b/dpcmd.h
@@ -78,8 +78,5 @@ bool Wait(const char* strOK,const char* strFail);
 void ExitProgram(void);
 int FirmwareUpdate();
 void sin_handler(int sig);
-int ctrlCCount;
-long int tvSec;
-long int tvUsec;
 
 #endif

--- a/usbdriver.c
+++ b/usbdriver.c
@@ -17,7 +17,10 @@ extern bool isSendFFsequence;
 #define SerialFlash_FALSE   -1
 #define SerialFlash_TRUE    1
 
+static int dev_index;
+static usb_device_entry_t   usb_device_entry[MAX_Dev_Index];
 static usb_dev_handle *dediprog_handle[MAX_Dev_Index];
+
 
 bool Is_NewUSBCommand(int Index)
 {

--- a/usbdriver.h
+++ b/usbdriver.h
@@ -44,8 +44,6 @@ typedef struct {
     unsigned long Length;
 } CNTRPIPE_RQ, *PCNTRPIPE_RQ;
 
-usb_device_entry_t   usb_device_entry[MAX_Dev_Index];
-
 /* Set/clear LEDs on dediprog */
 #define PASS_ON		(0 << 0)
 #define PASS_OFF	(1 << 0)
@@ -54,7 +52,6 @@ usb_device_entry_t   usb_device_entry[MAX_Dev_Index];
 #define ERROR_ON	(0 << 2)
 #define ERROR_OFF	(1 << 2)
 
-int dev_index;
 int usb_driver_init(void); 
 int get_usb_dev_cnt(void);
 int usb_driver_release(void);


### PR DESCRIPTION
EDIT: Updated description

Two global variables were declared as non-extern in the
`usb_driver.h` header file which caused the linker to complain
about multiple definiton errors when GCC 10+ was used. (See
https://gcc.gnu.org/gcc-10/porting_to.html for details.)

Instead of marking these variables extern, which was possible and
worked, they were moved to the source files because they were only used
in `usb_driver.c` where `usb_driver.h` was included.
    
Three other variables in `dpcmd.h` causing the linker errors were removed
because they were not used anywhere at all.