### PR TITLE
Fix array indexing in Condense()

### DIFF
--- a/project.c
+++ b/project.c
@@ -707,7 +707,7 @@ size_t Condense(uintptr_t* out, unsigned char* vc, uintptr_t* addrs, size_t addr
     for (j = 0; j < addrSize; j++) {
         for (i = addrs[j] - baseAddr; i < (addrs[j] - baseAddr + step); i++) {
             if (vc[i] != 0xFF) {
-                out[j] = addrs[j];
+                out[outSize] = addrs[j];
                 outSize++;
                 break;
             }


### PR DESCRIPTION
This fixes intermittent flash verify failures. The wrong array index was
used to accumulate the list of blocks that need to be programmed after
erase, leaving flash corrupted.