### PR TITLE
Change chip detect to use specified vcc value

### DIFF
--- a/project.c
+++ b/project.c
@@ -1286,9 +1286,7 @@ CHIP_INFO GetFirstDetectionMatch(char* TypeName, int Index)
                 g_Vcc = g_Vcc_temp;
             break;
         }
-        if (Loop == 1)
-            g_Vcc = vcc3_5V;
-        else
+        if (Loop != 1)
             g_Vcc = vcc1_8V - i;
 
         TurnONVcc(Index);


### PR DESCRIPTION
With the current code, I was not able to detect any 1.8V chips with an SF600. 

Additionally, I measured the pins physically, and indeed it was sending 3.5V to a 1.8V chip during detect. 
Removing VCC hardcode (and using argument specified voltage) allows chip detection with correct voltage.