### PR TITLE
Implement a fix for issue #61

### DIFF
--- a/project.c
+++ b/project.c
@@ -1502,16 +1502,6 @@ void SetProgReadCommand(int Index)
         mcode_Read = BULK_FAST_READ;
         mcode_Program = PP_32BYTE;
         mcode_SegmentErase = 0xD8;
-    } else if (strstr(Chip_Info.Class, SUPPORT_WINBOND_W25Pxx) != NULL) {
-
-        mcode_RDSR = RDSR;
-        mcode_WRSR = WRSR;
-        mcode_ChipErase = CHIP_ERASE;
-        mcode_Program = PAGE_PROGRAM;
-        mcode_Read = BULK_FAST_READ;
-        mcode_SegmentErase = SE;
-        mcode_ProgramCode_4Adr = 0x02;
-        mcode_ReadCode = 0x0B; 
     } else if (strstr(Chip_Info.Class, SUPPORT_WINBOND_W25Pxx_Large) != NULL) {
         mcode_RDSR = RDSR;
         mcode_WRSR = WRSR;
@@ -1521,6 +1511,15 @@ void SetProgReadCommand(int Index)
         mcode_SegmentErase = SE;
         mcode_ProgramCode_4Adr = 0x02;
         mcode_ReadCode = 0x0C;
+    } else if (strstr(Chip_Info.Class, SUPPORT_WINBOND_W25Pxx) != NULL) {
+        mcode_RDSR = RDSR;
+        mcode_WRSR = WRSR;
+        mcode_ChipErase = CHIP_ERASE;
+        mcode_Program = PAGE_PROGRAM;
+        mcode_Read = BULK_FAST_READ;
+        mcode_SegmentErase = SE;
+        mcode_ProgramCode_4Adr = 0x02;
+        mcode_ReadCode = 0x0B; 
     } else if (strstr(Chip_Info.Class, SUPPORT_ST_M25Pxx_Large) != NULL) {
         mcode_RDSR = RDSR;
         mcode_WRSR = WRSR;


### PR DESCRIPTION
Switch the order of if-statements for differentiation of Winbond flash sizes. For more details, see issue comments in #61 by @ozpaulb.

We encountered this bug as well for a `W25Q512JV-IQ` flash chip (64 MB), which in addition is suspected to lead to a failed verification of the flash content after a successful flash procedure.
We could not test this patch on our own yet, however, until then this PR shall provide an easy to merge implementation.