### PR TITLE
Use __DATE__ instead of hard-coding build date

### DIFF
--- a/dpcmd.c
+++ b/dpcmd.c
@@ -500,7 +500,7 @@ int main(int argc, char* argv[])
     unsigned long r;
     char* env;
 
-    printf("\nDpCmd Linux 1.14.11.%02d Engine Version:\nLast Built on January 7 2023\n\n", GetConfigVer()); // 1. new feature.bug.configS
+    printf("\nDpCmd Linux 1.14.11.%02d Engine Version:\nLast Built on %s\n\n", GetConfigVer(), __DATE__); // 1. new feature.bug.configS
 
     g_ucOperation = 0;
     GetLogPath(g_LogPath);


### PR DESCRIPTION
We can use the __DATE__ macro to automatically update the date that dpcmd was built, instead of hard-coding it.