### PR TITLE
Remove integer literal suffix "i" from non-complex

### DIFF
--- a/dpcmd.c
+++ b/dpcmd.c
@@ -1452,7 +1452,7 @@ bool CheckProgrammerInfo(void)
         uiFPGAVer = GetFPGAVersion(g_uiDevNum - 1);
         GetFirmwareVer(g_uiDevNum - 1);
         if (g_bIsSF600[g_uiDevNum - 1]) {
-            if (CheckSDCard(g_uiDevNum - 1i))
+            if (CheckSDCard(g_uiDevNum - 1))
                 printf("        Programmer type : SF600Plus\n");
             printf("        Programmer type : SF600Plus\n");
             printf("        Firmware version : %s\n", g_FW_ver);


### PR DESCRIPTION
GCC-aligned compilers may treat `1i` as complex number, refusing to proceed with “complex integral types are not supported” error message. Perhaps `1u` was meant, but that suffix is not used elsewhere, so I suggest removing it completely.