### PR TITLE
Disable forcing of default compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 endif
 
 PROGRAM = dpcmd
-CC      = gcc
+CC     ?= gcc
 PREFIX ?= /usr/local
 
 PKG_CONFIG ?= pkg-config


### PR DESCRIPTION
While [working on Yocto recipe](https://github.com/3mdeb/meta-rte/pull/69) for the `dpcmd` we ran into an issue where by default the makefile wouldn't cross-compile because of it overriding the environment CC value. By changing `=` to `?=`, the Makefile will adhere to best practices, allowing the correct compiler to be used when specified externally.