### PR TITLE
Makefile: add conditional stripping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,9 @@ install: $(PROGRAM)
 	[ $(shell id -u) -eq 0 ] || (echo "Error: install needs root privileges" && false)
 	install -v -o 0 -g 0 -m 755 -d $(DESTDIR)$(PREFIX)/bin $(DESTDIR)$(PREFIX)/share/DediProg
 	echo -n "install: " && install -v -o 0 -g 0 -m 0755 $(PROGRAM) $(DESTDIR)$(PREFIX)/bin/$(PROGRAM)
+ifneq ($(NOSTRIP),1)
 	strip $(DESTDIR)$(PREFIX)/bin/$(PROGRAM)
+endif
 	install -v -o 0 -g 0 -m 755 -d $(DESTDIR)$(PREFIX)/share/DediProg
 	echo -n "install: " && install -v -o 0 -g 0 -m 0644 ChipInfoDb.dedicfg $(DESTDIR)$(PREFIX)/share/DediProg/ChipInfoDb.dedicfg
 	install -v -o 0 -g 0 -m 755 -d $(DESTDIR)/etc/udev/rules.d


### PR DESCRIPTION
This patch introduces a `NOSTRIP` conditional flag to the `install` target in the Makefile. The purpose of this flag is to allow the disabling of binary stripping during installation. This is particularly useful in development environments, such as BitBake, which handle stripping internally.

When `NOSTRIP` is set to `1`, the `strip` command will be skipped during the installation process, preventing potential conflicts or redundant operations.

[Dediprog Flasher recipe thread in meta-oe Yocto layer](https://lists.openembedded.org/g/openembedded-devel/message/111417)