### PR TITLE
Add STRIP program path to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ endif
 
 PROGRAM = dpcmd
 CC     ?= gcc
+STRIP  ?= strip
 PREFIX ?= /usr/local
 
 PKG_CONFIG ?= pkg-config
@@ -59,7 +60,7 @@ install: $(PROGRAM)
 	install -v -o 0 -g 0 -m 755 -d $(DESTDIR)$(PREFIX)/bin $(DESTDIR)$(PREFIX)/share/DediProg
 	echo -n "install: " && install -v -o 0 -g 0 -m 0755 $(PROGRAM) $(DESTDIR)$(PREFIX)/bin/$(PROGRAM)
 ifneq ($(NOSTRIP),1)
-	strip $(DESTDIR)$(PREFIX)/bin/$(PROGRAM)
+	$(STRIP) $(DESTDIR)$(PREFIX)/bin/$(PROGRAM)
 endif
 	install -v -o 0 -g 0 -m 755 -d $(DESTDIR)$(PREFIX)/share/DediProg
 	echo -n "install: " && install -v -o 0 -g 0 -m 0644 ChipInfoDb.dedicfg $(DESTDIR)$(PREFIX)/share/DediProg/ChipInfoDb.dedicfg


### PR DESCRIPTION
Provide portable and cross-compilation friendly way to locate `strip` program.