### PR TITLE
dpcmd: Don't crash when an invalid long option is supplied

### DIFF
--- a/dpcmd.c
+++ b/dpcmd.c
@@ -222,6 +222,7 @@ struct option long_options[] = {
     
     { "set-io1", 1, NULL, '1' },
     { "set-io4", 1, NULL, '4' },
+    { },
 };
 
 int OpenUSB(void);


### PR DESCRIPTION
`getopt_long` requires a zero-filled terminating entry in the list of options.  This was missing.