### PR TITLE
Fix overwriting of g_uiDevNum during memcpy

### DIFF
--- a/Macro.h
+++ b/Macro.h
@@ -79,8 +79,9 @@ typedef enum {
 	GET_FW_STATUS   					=0x9B, //0x9A: Set  //0x9B:Get
 } USB_CMD;
 
+#define TYPENAME_MAX_LEN 64
 typedef struct ChipInfo {
-    char TypeName[100];
+    char TypeName[TYPENAME_MAX_LEN];
 	char ICType[16];
     size_t UniqueID;
 	size_t ChipIDMask;

--- a/dpcmd.c
+++ b/dpcmd.c
@@ -45,7 +45,7 @@ unsigned int g_uiDevNum = 0;
 unsigned int g_uiDeviceID = 0;
 unsigned int g_IO1Select = 0;
 unsigned int g_IO4Select = 1;
-char g_strTypeName[64] = "\0";
+char g_strTypeName[TYPENAME_MAX_LEN] = "\0";
 
 bool g_bEnableVpp = false;
 int g_StartupMode = STARTUP_APPLI_SF_1;


### PR DESCRIPTION
The following line in project.c in function GetFirstDetectionMatch was copying 100 bytes in an array of 64 bytes erasing several global variables like g_uiDevNum:

memcpy(TypeName,binfo.TypeName, sizeof(binfo.TypeName));