### PR TITLE
fix(dpcmd): prevent buffer overflow in FlashIdentifier

### DIFF
--- a/dpcmd.c
+++ b/dpcmd.c
@@ -2477,7 +2477,7 @@ int FlashIdentifier(CHIP_INFO* Chip_Info, int search_all, int Index)
         UniqueID = flash_ReadId(0x9f, 3, Index);
         if (UniqueID != 0) {
             rc = Dedi_Search_Chip_Db(TypeName, 0x9f, UniqueID, Chip_Info, search_all);
-            strcpy(g_strTypeName, TypeName);
+            snprintf(g_strTypeName, sizeof(g_strTypeName), "%s", TypeName);
             if (rc && (search_all == 0)) {
                 if (c == 1)
                     isSendFFsequence = true; 


### PR DESCRIPTION
This pull request makes a minor but important improvement to the way the chip type name is copied into the global string buffer in the `FlashIdentifier` function. The change replaces an unsafe string copy with a safer version to prevent potential buffer overflows.

- Improved buffer safety:
  * Replaced the use of `strcpy` with `snprintf` when copying `TypeName` into `g_strTypeName` in the `FlashIdentifier` function in `dpcmd.c`, ensuring the copy operation respects the destination buffer size.